### PR TITLE
Prevent Title texts on Controls Menu from being selected.

### DIFF
--- a/source/base/TextSelecting.hx
+++ b/source/base/TextSelecting.hx
@@ -1,5 +1,6 @@
 package base;
 
+import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 
 class TextSelecting extends FlxState
@@ -7,7 +8,7 @@ class TextSelecting extends FlxState
 	public var texts:Array<String> = ['uno', 'dos', 'tres', 'cuatro'];
 	public var text_group:FlxTypedGroup<FlxText> = new FlxTypedGroup<FlxText>();
 
-	public var CURRENT_SELECTION:Int = 0;
+	public var CURRENT_SELECTION(default, set):Int = 0;
 
 	public var customCamEnabled:Bool = false;
 	public var customCam:FlxObject;
@@ -51,7 +52,7 @@ class TextSelecting extends FlxState
 		if (canPressKeys())
 		{
 			controls();
-			outOfBoundsCheck();
+			// outOfBoundsCheck();
 		}
 
 		for (text in text_group)
@@ -72,15 +73,14 @@ class TextSelecting extends FlxState
 		return new FlxPoint(FlxG.width / 2, text.getGraphicMidpoint().y);
 	}
 
-	public function outOfBoundsCheck()
-	{
-		if (CURRENT_SELECTION < 0)
-			CURRENT_SELECTION = 0;
+	/*public function outOfBoundsCheck()
+		{
+			if (CURRENT_SELECTION < 0)
+				CURRENT_SELECTION = 0;
 
-		if (CURRENT_SELECTION > texts.length - 1)
-			CURRENT_SELECTION--;
-	}
-
+			if (CURRENT_SELECTION > texts.length - 1)
+				CURRENT_SELECTION--;
+	}*/
 	public dynamic function backKey() {}
 
 	public dynamic function enterKey() {}
@@ -108,5 +108,11 @@ class TextSelecting extends FlxState
 		{
 			backKey();
 		}
+	}
+
+	function set_CURRENT_SELECTION(val:Int):Int
+	{
+		// bounding
+		return CURRENT_SELECTION = Std.int(FlxMath.bound(val, 0, texts.length - 1));
 	}
 }

--- a/source/menus/options/ControlsMenu.hx
+++ b/source/menus/options/ControlsMenu.hx
@@ -26,7 +26,6 @@ class ControlsMenu extends TextSelecting
 		texts = [];
 
 		newControl('// GAMEPLAY CONTROLS \\\\', null);
-		CURRENT_SELECTION = 1;
 
 		newControl('Gameplay Shoot', 'gameplay_shoot');
 
@@ -52,6 +51,8 @@ class ControlsMenu extends TextSelecting
 
 		newControl('UI Select', 'ui_select');
 		newControl('UI Leave', 'ui_leave');
+
+		CURRENT_SELECTION = 1;
 
 		backKey = function()
 		{
@@ -110,7 +111,23 @@ class ControlsMenu extends TextSelecting
 	{
 		if (!buttonRemapping)
 		{
-			super.controls();
+			if (key_up)
+			{
+				changeSelection(-1);
+			}
+			else if (key_down)
+			{
+				changeSelection(1);
+			}
+			else if (key_enter)
+			{
+				enterKey();
+			}
+			else if (key_back)
+			{
+				backKey();
+			}
+			// we overridin' super.controls();
 		}
 		else
 		{
@@ -129,5 +146,23 @@ class ControlsMenu extends TextSelecting
 				}
 			}
 		}
+	}
+
+	function changeSelection(add:Int = 0)
+	{
+		// skip texts that doesn't have control id, used for titles.
+		var tempSelection:Int = CURRENT_SELECTION + add;
+		if (control_id.get(texts[tempSelection]) == null)
+		{
+			if (tempSelection + add < 0 || tempSelection + add > texts.length - 1)
+				return;
+			else
+			{
+				CURRENT_SELECTION = tempSelection;
+				changeSelection(add);
+				return;
+			}
+		}
+		CURRENT_SELECTION += add;
 	}
 }


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
Nope.

## Briefly describe the issue(s) fixed.
This fixes a small thing where the title texts in the Controls Menu could be selected. They’re not meant to be interacted with, so it makes more sense to just skip over them when navigating.

Also added a small adjustment: the CURRENT_SELECTION bounding now uses FlxMath.bound along with proper setters.

## Include any relevant screenshots or videos.
https://github.com/user-attachments/assets/c8653e10-86d2-40c3-9951-0a066bea6dd3